### PR TITLE
friends: prettify forall symbol uniformly

### DIFF
--- a/emacs/boogie-friends.el
+++ b/emacs/boogie-friends.el
@@ -76,7 +76,7 @@
 (defconst boogie-friends-symbols-alist '(("<=" . ?≤) (">=" . ?≥) ("!=" . ?≠) (":=" . ?≔)
                                          ("&&" . ?∧) ("||" . ?∨) ("=>" . ?⇒) ("->" . ?→)
                                          ("<==>" . ?⟺) ("==>" . ?⟹) ("<==" . ?⟸)
-                                         ("exists" . ?∃) ("::" . ?∙))
+                                         ("forall" . ?∀) ("exists" . ?∃) ("::" . ?∙))
   "Symbols used in conjunction with `prettify-minor-mode'.")
 
 (defface boogie-friends-flycheck-tooltip

--- a/emacs/boogie-mode.el
+++ b/emacs/boogie-mode.el
@@ -97,10 +97,7 @@ with a prefix arg."
      (cons (concat "\\(" (regexp-opt '("bool" "int" "real") 'symbols) "\\)\\|\\(\\_<bv[0-9]+\\_>\\)") font-lock-type-face)
      (list "{:[^{\n]+}" '(0 font-lock-constant-face append))
      (list "\\({\\s-*\\)\\([^{\n]+?\\)\\(\\s-*}\\)"
-           '(1 font-lock-constant-face) '(2 '(face italic) prepend) '(3 font-lock-constant-face))
-     (list "\\(\\_<forall\\)\\(\\_>\\|<[^>]>\\)?"
-           '(1 (compose-region (match-beginning 1) (match-end 1) ?∀))
-           '(1 font-lock-keyword-face append))))
+           '(1 font-lock-constant-face) '(2 '(face italic) prepend) '(3 font-lock-constant-face))))
   "Font lock specifications for `boogie-mode'.")
 
 (defvar boogie-mode-map

--- a/emacs/dafny-mode.el
+++ b/emacs/dafny-mode.el
@@ -189,10 +189,7 @@ the return value."
    (cons "!\\_<in\\_>" font-lock-keyword-face) ;; Needed because '!' is not part of a symbol, so adding '!in' to keywords doesn't work
    (cons dafny-keywords-regexp font-lock-keyword-face)
    (cons dafny-types-regexp font-lock-type-face)
-   (list "\\(!\\)\\([^=i!]\\|$\\)" 1 font-lock-negation-char-face)
-   (list "\\(\\_<forall\\_>\\).*?::"
-         '(1 (compose-region (match-beginning 1) (match-end 1) ?∀))
-         '(1 font-lock-keyword-face append)))
+   (list "\\(!\\)\\([^=i!]\\|$\\)" 1 font-lock-negation-char-face))
   "Font lock specifications for `dafny-mode'.")
 
 (defun dafny-ignore-event (_e)


### PR DESCRIPTION
For some reason prettifying of the forall symbol was hard coded in the Boogie and Dafny mode. I noticed that when disabling prettify-symbols-mode did not take effect for forall.