### PR TITLE
Give / punctuation syntax, fixes comment-region bug

### DIFF
--- a/emacs/dafny-mode.el
+++ b/emacs/dafny-mode.el
@@ -223,8 +223,8 @@ Useful to ignore mouse-up events handled mouse-down events."
     (modify-syntax-entry ?_  "w" tbl)
     ;; Comments
     (modify-syntax-entry ?\n ">" tbl)
-    (modify-syntax-entry ?/  "  124" tbl)
-    (modify-syntax-entry ?*  "  23bn" tbl)
+    (modify-syntax-entry ?/  ". 124" tbl)
+    (modify-syntax-entry ?*  ". 23bn" tbl)
     tbl)
   "Syntax table for `dafny-mode'.")
 


### PR DESCRIPTION
Comment syntax in dafny-mode breaks comment-region in recent versions
of Emacs.  The problem is that that method reasonably assumes
`commment-start' has a non-whitespace character.  This change gives /
the proper punctuation syntax (as it is in c++-mode for example).