### PR TITLE
LSP-Dafny Counterexamples - Fix string-match error

### DIFF
--- a/emacs/lsp-dafny.el
+++ b/emacs/lsp-dafny.el
@@ -420,7 +420,7 @@ details."
 
 (defun lsp-dafny--counterexamples-format-line (variable value indent)
   "Format a VARIABLE and its VALUE for display, indented by INDENT."
-  (let* ((sep (string-match ":" variable nil t))
+  (let* ((sep (string-match ":" variable))
          (typ (if sep (substring variable (1+ sep)) "??"))
          (variable (if sep (substring variable 0 sep) variable))
          (line (format "%s%s: %s := %s\n"


### PR DESCRIPTION
Enabling `lsp-dafny-counterexamples-mode` was causing the following error: 

`lsp-dafny--counterexamples-format-line: Wrong number of arguments: #<subr string-match>, 4`

string-match function takes at most 3 arguments (the third is optional).
